### PR TITLE
Added support for the new mixin inject syntax

### DIFF
--- a/src/main/java/de/neuland/jade4j/lexer/Lexer.java
+++ b/src/main/java/de/neuland/jade4j/lexer/Lexer.java
@@ -8,31 +8,7 @@ import java.util.regex.Matcher;
 import org.apache.commons.lang3.StringUtils;
 
 import de.neuland.jade4j.exceptions.JadeLexerException;
-import de.neuland.jade4j.lexer.token.Block;
-import de.neuland.jade4j.lexer.token.CaseToken;
-import de.neuland.jade4j.lexer.token.Colon;
-import de.neuland.jade4j.lexer.token.Comment;
-import de.neuland.jade4j.lexer.token.Conditional;
-import de.neuland.jade4j.lexer.token.CssClass;
-import de.neuland.jade4j.lexer.token.CssId;
-import de.neuland.jade4j.lexer.token.Default;
-import de.neuland.jade4j.lexer.token.Doctype;
-import de.neuland.jade4j.lexer.token.Dot;
-import de.neuland.jade4j.lexer.token.Eos;
-import de.neuland.jade4j.lexer.token.Expression;
-import de.neuland.jade4j.lexer.token.ExtendsToken;
-import de.neuland.jade4j.lexer.token.Filter;
-import de.neuland.jade4j.lexer.token.Include;
-import de.neuland.jade4j.lexer.token.Indent;
-import de.neuland.jade4j.lexer.token.Mixin;
-import de.neuland.jade4j.lexer.token.Newline;
-import de.neuland.jade4j.lexer.token.Outdent;
-import de.neuland.jade4j.lexer.token.Tag;
-import de.neuland.jade4j.lexer.token.Text;
-import de.neuland.jade4j.lexer.token.Token;
-import de.neuland.jade4j.lexer.token.When;
-import de.neuland.jade4j.lexer.token.While;
-import de.neuland.jade4j.lexer.token.Yield;
+import de.neuland.jade4j.lexer.token.*;
 import de.neuland.jade4j.template.TemplateLoader;
 
 public class Lexer {
@@ -108,6 +84,9 @@ public class Lexer {
 		}
 		if (token == null) {
 			token = mixin();
+		}
+		if (token == null) {
+			token = mixinInject();
 		}
 		if (token == null) {
 			token = conditional();
@@ -514,6 +493,17 @@ public class Lexer {
 		Matcher matcher = scanner.getMatcherForPattern("^mixin +([-\\w]+)(?: *\\((.*)\\))?");
 		if (matcher.find(0) && matcher.groupCount() > 1) {
 			Mixin tok = new Mixin(matcher.group(1), lineno);
+			tok.setArguments(matcher.group(2));
+			consume(matcher.end());
+			return tok;
+		}
+		return null;
+	}
+        
+        private Token mixinInject() {
+		Matcher matcher = scanner.getMatcherForPattern("^\\++([-\\w]+)(?: *\\((.*)\\))?");
+		if (matcher.find(0) && matcher.groupCount() > 1) {
+			MixinInject tok = new MixinInject(matcher.group(1), lineno);
 			tok.setArguments(matcher.group(2));
 			consume(matcher.end());
 			return tok;

--- a/src/main/java/de/neuland/jade4j/lexer/token/MixinInject.java
+++ b/src/main/java/de/neuland/jade4j/lexer/token/MixinInject.java
@@ -1,0 +1,20 @@
+package de.neuland.jade4j.lexer.token;
+
+
+public class MixinInject extends Token {
+
+	private String arguments;
+
+    public MixinInject(String value, int lineNumber) {
+		super(value, lineNumber);
+	}
+
+    public void setArguments(String args) {
+        this.arguments = args;
+    }
+    
+    public String getArguments() {
+        return arguments;
+    }
+
+}

--- a/src/main/java/de/neuland/jade4j/parser/Parser.java
+++ b/src/main/java/de/neuland/jade4j/parser/Parser.java
@@ -14,47 +14,8 @@ import de.neuland.jade4j.exceptions.JadeParserException;
 import de.neuland.jade4j.lexer.Assignment;
 import de.neuland.jade4j.lexer.Each;
 import de.neuland.jade4j.lexer.Lexer;
-import de.neuland.jade4j.lexer.token.Attribute;
-import de.neuland.jade4j.lexer.token.Block;
-import de.neuland.jade4j.lexer.token.CaseToken;
-import de.neuland.jade4j.lexer.token.Colon;
-import de.neuland.jade4j.lexer.token.Comment;
-import de.neuland.jade4j.lexer.token.Conditional;
-import de.neuland.jade4j.lexer.token.CssClass;
-import de.neuland.jade4j.lexer.token.CssId;
-import de.neuland.jade4j.lexer.token.Default;
-import de.neuland.jade4j.lexer.token.Doctype;
-import de.neuland.jade4j.lexer.token.Dot;
-import de.neuland.jade4j.lexer.token.Eos;
-import de.neuland.jade4j.lexer.token.Expression;
-import de.neuland.jade4j.lexer.token.ExtendsToken;
-import de.neuland.jade4j.lexer.token.Filter;
-import de.neuland.jade4j.lexer.token.Include;
-import de.neuland.jade4j.lexer.token.Indent;
-import de.neuland.jade4j.lexer.token.Mixin;
-import de.neuland.jade4j.lexer.token.Newline;
-import de.neuland.jade4j.lexer.token.Outdent;
-import de.neuland.jade4j.lexer.token.Tag;
-import de.neuland.jade4j.lexer.token.Text;
-import de.neuland.jade4j.lexer.token.Token;
-import de.neuland.jade4j.lexer.token.When;
-import de.neuland.jade4j.lexer.token.While;
-import de.neuland.jade4j.lexer.token.Yield;
-import de.neuland.jade4j.parser.node.AssigmentNode;
-import de.neuland.jade4j.parser.node.BlockNode;
-import de.neuland.jade4j.parser.node.CaseConditionNode;
-import de.neuland.jade4j.parser.node.CaseNode;
-import de.neuland.jade4j.parser.node.ConditionalNode;
-import de.neuland.jade4j.parser.node.DoctypeNode;
-import de.neuland.jade4j.parser.node.EachNode;
-import de.neuland.jade4j.parser.node.ExpressionNode;
-import de.neuland.jade4j.parser.node.FilterNode;
-import de.neuland.jade4j.parser.node.LiteralNode;
-import de.neuland.jade4j.parser.node.MixinNode;
-import de.neuland.jade4j.parser.node.Node;
-import de.neuland.jade4j.parser.node.TagNode;
-import de.neuland.jade4j.parser.node.TextNode;
-import de.neuland.jade4j.parser.node.WhileNode;
+import de.neuland.jade4j.lexer.token.*;
+import de.neuland.jade4j.parser.node.*;
 import de.neuland.jade4j.template.TemplateLoader;
 
 public class Parser {
@@ -106,6 +67,9 @@ public class Parser {
 		}
 		if (token instanceof Mixin) {
 			return parseMixin();
+		}
+                if (token instanceof MixinInject) {
+			return parseMixinInject();
 		}
 		if (token instanceof Block) {
 			return parseBlock();
@@ -188,6 +152,22 @@ public class Parser {
 		}
 		return node;
 	}
+        
+        private Node parseMixinInject() {
+                Token token = expect(MixinInject.class);
+		MixinInject mixinInjectToken = (MixinInject) token;
+		MixinInjectNode node = new MixinInjectNode();
+		node.setName(mixinInjectToken.getValue());
+		node.setLineNumber(mixinInjectToken.getLineNumber());
+		node.setFileName(filename);
+		if (StringUtils.isNotBlank(mixinInjectToken.getArguments())) {
+			node.setArguments(mixinInjectToken.getArguments());
+		}
+		if (peek() instanceof Indent) {
+			node.setBlock(block());
+		}
+		return node;
+        }
 
 	private Node parseCssClassOrId() {
 		Token tok = nextToken();

--- a/src/main/java/de/neuland/jade4j/parser/node/MixinInjectNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/MixinInjectNode.java
@@ -1,0 +1,63 @@
+package de.neuland.jade4j.parser.node;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ognl.Ognl;
+import ognl.OgnlException;
+import de.neuland.jade4j.compiler.IndentWriter;
+import de.neuland.jade4j.exceptions.JadeCompilerException;
+import de.neuland.jade4j.model.JadeModel;
+import de.neuland.jade4j.template.JadeTemplate;
+
+public class MixinInjectNode extends Node {
+    
+    private List<String> arguments = new ArrayList<String>();
+    
+    @Override
+    public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
+        MixinNode mixin = model.getMixin(getName());
+        if (mixin == null) {
+            throw new JadeCompilerException(this, template.getTemplateLoader(), "mixin " + getName() + " is not defined");
+        }
+        model.pushScope();
+        writeVariables(model, mixin, template);
+        mixin.getBlock().execute(writer, model, template);
+        model.popScope();
+    }
+    
+    private void writeVariables(JadeModel model, MixinNode mixin, JadeTemplate template) {
+        List<String> names = mixin.getArguments();
+        List<String> values = arguments;
+        if (names == null) {
+            return;
+        }
+        for (int i = 0; i < values.size(); i++) {
+            String key = names.get(i);
+            Object value = null;
+            try {
+                value = Ognl.getValue(values.get(i), model);
+            } catch (OgnlException e) {
+                throw new JadeCompilerException(this, template.getTemplateLoader(), e);
+            }
+            if (key != null) {
+                model.put(key, value);
+            }
+        }
+    }
+    
+    public List<String> getArguments() {
+        return arguments;
+    }
+    
+    public void setArguments(List<String> arguments) {
+        this.arguments = arguments;
+    }
+    
+    public void setArguments(String arguments) {
+        this.arguments.clear();
+        for (String argument : arguments.split(",")) {
+            this.arguments.add(argument.trim());
+        }
+    }
+}

--- a/src/main/java/de/neuland/jade4j/parser/node/MixinNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/MixinNode.java
@@ -1,68 +1,19 @@
 package de.neuland.jade4j.parser.node;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import ognl.Ognl;
-import ognl.OgnlException;
 import de.neuland.jade4j.compiler.IndentWriter;
 import de.neuland.jade4j.exceptions.JadeCompilerException;
 import de.neuland.jade4j.model.JadeModel;
 import de.neuland.jade4j.template.JadeTemplate;
 
-public class MixinNode extends Node {
-
-	private List<String> arguments = new ArrayList<String>();
+public class MixinNode extends MixinInjectNode {
 
 	@Override
 	public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
 		if (hasBlock()) {
 			model.setMixin(getName(), this);
 		} else {
-			MixinNode mixin = model.getMixin(getName());
-			if (mixin == null) {
-				throw new JadeCompilerException(this, template.getTemplateLoader(), "mixin " + getName() + " is not defined");
-			}
-			model.pushScope();
-			writeVariables(model, mixin, template);
-			mixin.getBlock().execute(writer, model, template);
-			model.popScope();
+			super.execute(writer, model, template);
 		}
 	}
-
-	private void writeVariables(JadeModel model, MixinNode mixin, JadeTemplate template) {
-		List<String> names = mixin.getArguments();
-		List<String> values = arguments;
-		if (names == null) {
-			return;
-		}
-		for (int i = 0; i < values.size(); i++) {
-			String key = names.get(i);
-			Object value = null;
-			try {
-				value = Ognl.getValue(values.get(i), model);
-			} catch (OgnlException e) {
-				throw new JadeCompilerException(this, template.getTemplateLoader(), e);
-			}
-			if (key != null) {
-				model.put(key, value);
-			}
-		}
-	}
-
-	public List<String> getArguments() {
-		return arguments;
-	}
-
-	public void setArguments(List<String> arguments) {
-		this.arguments = arguments;
-	}
-
-	public void setArguments(String arguments) {
-		this.arguments.clear();
-		for (String argument : arguments.split(",")) {
-			this.arguments.add(argument.trim());
-		}
-	}
-
+	
 }

--- a/src/test/resources/compiler/mixin.html
+++ b/src/test/resources/compiler/mixin.html
@@ -1,1 +1,1 @@
-<h1>hello</h1><h2>world</h2><h3>world</h3>
+<h1>hello</h1><h2>world</h2><h3>world</h3><h1>hello</h1><h2>world</h2><h3>world</h3>

--- a/src/test/resources/compiler/mixin.jade
+++ b/src/test/resources/compiler/mixin.jade
@@ -7,3 +7,6 @@ mixin hello
   
 mixin say("hello", "world")
 mixin hello
+
++say("hello", "world")
++hello

--- a/src/test/resources/originalTests/includes.html
+++ b/src/test/resources/originalTests/includes.html
@@ -1,1 +1,1 @@
-<p>bar</p><body><!--include auxiliary/smile.html--><!--include auxiliary/escapes.html--></body>
+<p>bar</p><p>bar</p><body><!--include auxiliary/smile.html--><!--include auxiliary/escapes.html--></body>

--- a/src/test/resources/originalTests/includes.jade
+++ b/src/test/resources/originalTests/includes.jade
@@ -2,6 +2,7 @@
 include auxiliary/mixins
 
 mixin foo()
++foo()
 
 body
   //include auxiliary/smile.html


### PR DESCRIPTION
Jade is implemeting af new syntax for mixin injections.

Syntax:

```
+<mixinname>[([arguments])]
```

Example:

```
+foo('bar')
```

I have commited an implementation for this syntax that still supports the original syntax. Only difference between the new and the old syntax is that the new syntax supports having subnodes renderes for the injection.

Example:

```
mixin foo
   .foo bar

p
    mixin foo
        p Sub content  //Wont be displayed
    +foo
        p Sub content  //Will be displayed
```
