### PR TITLE
Fixes #9 regarding filenamehandling on windows causing project not to build.

### DIFF
--- a/src/main/java/de/neuland/jade4j/parser/Parser.java
+++ b/src/main/java/de/neuland/jade4j/parser/Parser.java
@@ -1,7 +1,6 @@
 package de.neuland.jade4j.parser;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -284,15 +283,42 @@ public class Parser {
 	}
 
 	private Parser createParser(String templateName) {
-		URI currentUri = URI.create(filename);
-		URI templateUri = currentUri.resolve(templateName);
-		try {
-			return new Parser(templateUri.toString(), templateLoader);
+                String resolvedName = resolveFilename(templateName);
+                
+                try {
+			return new Parser(resolvedName, templateLoader);
 		} catch (IOException e) {
 			throw new JadeParserException(filename, lexer.getLineno(), templateLoader, "the template [" + templateName
 					+ "] could not be opened\n" + e.getMessage());
 		}
 	}
+        
+        private String resolveFilename(String templateName) {
+                String resolvedName;
+                if(templateName.startsWith("/")) {
+                    //If starting with slash then its an absolute filename
+                    resolvedName = templateName;
+                } else {
+                    resolvedName = filename;
+                    resolvedName = resolvedName.replace("\\", "/");
+                    
+                    //Remove endling slash
+                    if(resolvedName.endsWith("/")) {  
+                        resolvedName = resolvedName.substring(0, resolvedName.length()-1);
+                    }
+                    
+                    int lastSlashIndex = resolvedName.lastIndexOf("/");
+                    if(lastSlashIndex>=0 && lastSlashIndex < resolvedName.length()-1) {
+                        //If slashes found then replace the part after the last slash.
+                        resolvedName = resolvedName.substring(0,lastSlashIndex+1) + templateName;
+                    } else {
+                        //..or else treat the templatename as the complete name
+                        resolvedName = templateName;
+                    }
+                    
+                }
+                return resolvedName;
+        }
 
 	private BlockNode parseYield() {
 		nextToken();

--- a/src/main/java/de/neuland/jade4j/template/FileTemplateLoader.java
+++ b/src/main/java/de/neuland/jade4j/template/FileTemplateLoader.java
@@ -2,21 +2,22 @@ package de.neuland.jade4j.template;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.io.Reader;
 
 public class FileTemplateLoader implements TemplateLoader {
 	
 	private String encoding = "UTF-8";
 	private String suffix = ".jade";
-	private String basePath = "";
+	private final File basePath;
 	
-	public FileTemplateLoader(String basePath, String encoding) {
-		this.basePath = basePath;
+        public FileTemplateLoader(String basePath, String encoding) {
+		this.basePath = basePath == null || "".equals(basePath) ? null : new File(basePath);
 		this.encoding = encoding;
 	}
 
+        @Override
 	public long getLastModified(String name) {
 		File templateSource = getFile(name);
 		return templateSource.lastModified();
@@ -30,10 +31,16 @@ public class FileTemplateLoader implements TemplateLoader {
 
 	private File getFile(String name) {
 		// TODO Security
-		String filename = basePath + name;
-		if (!filename.endsWith(suffix)) {
-			filename += suffix;
+                if (!name.endsWith(suffix)) {
+			name += suffix;
 		}
-		return new File(filename);
+		
+		File file;
+                if(basePath == null) {
+                    file = new File(name);
+                } else {
+                    file = new File(basePath, name);
+                }
+		return file;
 	}
 }


### PR DESCRIPTION
I changed FileTemplateLoader and Parser just a tad.

FileTemplateLoader now internally uses a File object instead of Strings making it easier to concatenate file paths.

Parser now has a custom method for resolving the filename from a templatename instead of using the URI class.
