### PR TITLE
Full support for mixin attributes

### DIFF
--- a/src/main/java/de/neuland/jade4j/parser/Parser.java
+++ b/src/main/java/de/neuland/jade4j/parser/Parser.java
@@ -194,13 +194,14 @@ public class Parser {
 		return node;
 	}
         
-        private Node parseMixinInject() {
-                Token token = expect(MixinInject.class);
+    private Node parseMixinInject() {
+        Token token = expect(MixinInject.class);
 		MixinInject mixinInjectToken = (MixinInject) token;
 		MixinInjectNode node = new MixinInjectNode();
 		node.setName(mixinInjectToken.getValue());
 		node.setLineNumber(mixinInjectToken.getLineNumber());
 		node.setFileName(filename);
+
 		if (StringUtils.isNotBlank(mixinInjectToken.getArguments())) {
 			node.setArguments(mixinInjectToken.getArguments());
 		}
@@ -213,20 +214,21 @@ public class Parser {
 	        } else if (incomingToken instanceof CssClass) {
 		        Token tok = nextToken();
 		        node.addAttribute("class", tok.getValue());
-		    // TODO Add attribute support in addition to argument support, need to fix lexer.
-	        //} else if (incomingToken instanceof Attribute) {
-		    //    Attribute tok = (Attribute) nextToken();
-		    //    node.addAttributes(tok.getAttributes());
-		    //    continue;
+	        } else if (incomingToken instanceof Attribute) {
+		        Attribute tok = (Attribute) nextToken();
+		        node.addAttributes(tok.getAttributes());
 	        } else {
 		        break;
 	        }
         }
-		if (peek() instanceof Indent) {
+
+	    if (peek() instanceof Text) {
+		    node.setBlock(parseText());
+	    } else if (peek() instanceof Indent) {
 			node.setBlock(block());
 		}
 		return node;
-        }
+    }
 
 	private Node parseCssClassOrId() {
 		Token tok = nextToken();

--- a/src/main/java/de/neuland/jade4j/parser/node/MixinInjectNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/MixinInjectNode.java
@@ -95,12 +95,7 @@ public class MixinInjectNode extends AttributedNode {
     }
 
 	private void writeAttributes(JadeModel model, MixinNode mixin, JadeTemplate template) {
-		for (Node node : mixin.getBlock().getNodes()) {
-			if (node instanceof AttributedNode) {
-				AttributedNode attributedNode = (AttributedNode) node;
-				attributedNode.addAttributes(attributes);
-			}
-		}
+		model.put("attributes", mergeInheritedAttributes(model));
 	}
     
     public List<String> getArguments() {

--- a/src/main/java/de/neuland/jade4j/parser/node/TagNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/TagNode.java
@@ -92,19 +92,18 @@ public class TagNode extends AttributedNode {
 	}
 
 	private String attributes(JadeModel model, JadeTemplate template) {
-		StringBuilder sb = new StringBuilder("");
-		for (String name : this.attributes.keySet()) {
-			if (this.attributes.containsKey(name)) {
-				Object value = this.attributes.get(name);
-				String attributeString;
-				try {
-					attributeString = getAttributeString(name, value, model, template);
-				} catch (ExpressionException e) {
-					throw new JadeCompilerException(this, template.getTemplateLoader(), e);
-				}
-				sb.append(attributeString);
+		StringBuilder sb = new StringBuilder();
+
+		Map<String, Object> mergedAttributes = mergeInheritedAttributes(model);
+
+		for (Map.Entry<String, Object> entry : mergedAttributes.entrySet()) {
+			try {
+				sb.append(getAttributeString(entry.getKey(), entry.getValue(), model, template));
+			} catch (ExpressionException e) {
+				throw new JadeCompilerException(this, template.getTemplateLoader(), e);
 			}
 		}
+
 		return sb.toString();
 	}
 

--- a/src/test/java/de/neuland/jade4j/compiler/CompilerTest.java
+++ b/src/test/java/de/neuland/jade4j/compiler/CompilerTest.java
@@ -213,6 +213,16 @@ public class CompilerTest {
 	}
 
 	@Test
+	public void mixinAttrs() {
+		run("mixin_attrs", true);
+	}
+
+	@Test
+	public void mixinMerge() {
+		run("mixin_merge", true);
+	}
+
+	@Test
 	public void include1() {
 		run("include_1");
 	}

--- a/src/test/resources/compiler/mixin_attrs.html
+++ b/src/test/resources/compiler/mixin_attrs.html
@@ -1,0 +1,27 @@
+<body>
+  <div class="centered" id="First">Hello World
+  </div>
+  <div class="centered" id="Second">
+    <h1>Section 1</h1>
+    <p>Some important content.</p>
+  </div>
+  <div class="centered" id="Third">
+    <h1 class="foo bar">Section 2</h1>
+    <p>Even more important content.</p>
+    <div class="footer">
+      <a href="menu.html">Back</a>
+    </div>
+  </div>
+  <div class="stretch">
+    <div class="centered">
+      <h1 class="highlight">Section 3</h1>
+      <p>Last content.</p>
+      <div class="footer">
+        <a href="#">Back</a>
+      </div>
+    </div>
+  </div>
+  <div class="bottom foo bar" id="Last" data-attr="baz" name="end">
+    <p>Some final words.</p>
+  </div>
+</body>

--- a/src/test/resources/compiler/mixin_attrs.jade
+++ b/src/test/resources/compiler/mixin_attrs.jade
@@ -1,0 +1,28 @@
+mixin centered(title)
+  div.centered(id=attributes.id)
+    if title
+      h1(class=attributes.class)= title
+    block
+    if attributes.href
+      .footer
+        a(href=attributes.href) Back
+
+mixin main(title)
+  div.stretch
+    +centered(title).highlight(attributes)
+      block
+
+mixin bottom
+  div.bottom(attributes)
+    block
+
+body
+  +centered#First Hello World
+  +centered('Section 1')#Second
+    p Some important content.
+  +centered('Section 2')#Third.foo(href='menu.html', class='bar')
+    p Even more important content.
+  +main('Section 3')(href='#')
+    p Last content.
+  +bottom.foo(class='bar', name='end', id='Last', data-attr='baz')
+    p Some final words.

--- a/src/test/resources/compiler/mixin_merge.html
+++ b/src/test/resources/compiler/mixin_merge.html
@@ -1,0 +1,30 @@
+<body>
+  <p class="bar hello">One</p>
+  <p class="baz quux hello">Two</p>
+  <p class="hello">Three</p>
+  <p class="bar baz hello">Four</p>
+  <p class="bar" id="world">One</p>
+  <p class="baz quux" id="world">Two</p>
+  <p id="world">Three</p>
+  <p class="bar baz" id="world">Four</p>
+  <p class="bar hello" id="world">One</p>
+  <p class="baz quux hello" id="world">Two</p>
+  <p class="hello" id="world">Three</p>
+  <p class="bar baz hello" id="world">Four</p>
+  <p class="bar hello world">One</p>
+  <p class="baz quux hello world">Two</p>
+  <p class="hello world">Three</p>
+  <p class="bar baz hello world">Four</p>
+  <p class="bar hello">One</p>
+  <p class="baz quux hello">Two</p>
+  <p class="hello">Three</p>
+  <p class="bar baz hello">Four</p>
+  <p class="bar hello world">One</p>
+  <p class="baz quux hello world">Two</p>
+  <p class="hello world">Three</p>
+  <p class="bar baz hello world">Four</p>
+  <p class="bar">One</p>
+  <p class="baz quux">Two</p>
+  <p>Three</p>
+  <p class="bar baz">Four</p>
+</body>

--- a/src/test/resources/compiler/mixin_merge.jade
+++ b/src/test/resources/compiler/mixin_merge.jade
@@ -1,0 +1,14 @@
+mixin foo
+  p.bar(attributes) One
+  p.baz.quux(attributes) Two
+  p(attributes) Three
+  p.bar(attributes, class="baz") Four
+
+body
+  +foo.hello
+  +foo#world
+  +foo.hello#world
+  +foo.hello.world
+  +foo(class="hello")
+  +foo.hello(class="world")
+  +foo


### PR DESCRIPTION
These are the remaining changes to provide jade4j compatibility with the mixin attribute capability in the current version of jade.  I have included two test cases from visionmedia/jade with exercise the functionality including attribute merging.

This pull request adds support for passing arbitrary attributes as well as special handling of the "attributes" attribute for mixins and tags.
