### PR TITLE
Fix a bug when using expression string in mixins

### DIFF
--- a/src/main/java/de/neuland/jade4j/parser/node/AttributedNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/AttributedNode.java
@@ -58,12 +58,16 @@ public abstract class AttributedNode extends Node {
 	 * "class" attribute.
 	 */
 	private void addAttribute(Map<String, Object> map, String key, Object value) {
-		if ("class".equals(key) && attributes.containsKey(key)) {
-			attributes.put(key, new StringBuilder((String) attributes.get(key)).append(" ").append(value).toString());
-		} else {
-			attributes.put(key, value);
-		}
-	}
+        if ("class".equals(key) && attributes.containsKey(key)) {
+           if(value instanceof ExpressionString) {
+                attributes.put(key, new ExpressionString(new StringBuilder("\"").append((String) attributes.get(key)).append(" \" + ").append(((ExpressionString) value).getValue()).toString()));
+            } else {
+                attributes.put(key, new StringBuilder((String) attributes.get(key)).append(" ").append(value).toString());
+            }
+        } else {
+            attributes.put(key, value);
+        }
+    }
 
 	@Override
 	public AttributedNode clone() throws CloneNotSupportedException {

--- a/src/test/java/de/neuland/jade4j/parser/MixinsTest.java
+++ b/src/test/java/de/neuland/jade4j/parser/MixinsTest.java
@@ -1,0 +1,23 @@
+package de.neuland.jade4j.parser;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import de.neuland.jade4j.Jade4J;
+import de.neuland.jade4j.TestFileHelper;
+
+public class MixinsTest extends ParserTest {
+
+
+    @Test
+    public void shouldReturnABlockWithTokens2() throws Exception {
+        String path = TestFileHelper.getResourcePath("/parser/mixins_with_attributes.jade");
+        String render = Jade4J.render(path, new HashMap<String, Object>());
+        assertThat(render,is("<div class=\"templates\"><div class=\"block positif\">content</div></div>"));
+        System.out.println(render);
+    }
+
+}

--- a/src/test/resources/parser/mixins_with_attributes.jade
+++ b/src/test/resources/parser/mixins_with_attributes.jade
@@ -1,0 +1,5 @@
+mixin bloc(style)
+  .block(class=style) content
+
+.templates
+        mixin bloc('positif')


### PR DESCRIPTION
Hi,

Here is a pull request that fixes a bug when using mixins like 

mixin bloc(style)
  .block(class=style) content

was evaluated to <div class="blog de.neuland....ExpressionString@1234"> content</div>

There is a test (perhaps at a too high level) that checks that the fix works.
