### PR TITLE
  Remove slf4j and address minor formatting issue (tabs vs spaces) in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,17 +71,6 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.12</version>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<excludes>
-						<include>**/log4j.xml</include>
-						<include>**/log4j.dtd</include>
-					</excludes>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 
@@ -113,25 +102,12 @@
 		</dependency>
 
         <dependency>
-          <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-          <artifactId>concurrentlinkedhashmap-lru</artifactId>
-          <version>1.3.1</version>
-        </dependency>
-
-		<!-- Other dependencies -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.6.0</version>
+			<groupId>com.googlecode.concurrentlinkedhashmap</groupId>
+			<artifactId>concurrentlinkedhashmap-lru</artifactId>
+			<version>1.3.1</version>
 		</dependency>
 
 		<!-- Testing -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.0</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>

--- a/src/main/java/de/neuland/jade4j/JadeConfiguration.java
+++ b/src/main/java/de/neuland/jade4j/JadeConfiguration.java
@@ -6,9 +6,6 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 
 import de.neuland.jade4j.Jade4J.Mode;
@@ -30,9 +27,6 @@ public class JadeConfiguration {
 	private static final String FILTER_CDATA = "cdata";
 
 	private static final String FILTER_PLAIN = "plain";
-
-	@SuppressWarnings("unused")
-	private static Logger logger = LoggerFactory.getLogger(JadeConfiguration.class);
 
 	private boolean prettyPrint = false;
 	private boolean caching = true;

--- a/src/main/java/de/neuland/jade4j/model/JadeModel.java
+++ b/src/main/java/de/neuland/jade4j/model/JadeModel.java
@@ -11,18 +11,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import de.neuland.jade4j.filter.Filter;
 import de.neuland.jade4j.parser.node.MixinNode;
 
 public class JadeModel implements Map<String, Object> {
 
 	private static final String LOCALS = "locals";
-
-	@SuppressWarnings("unused")
-	private static final Logger logger = LoggerFactory.getLogger(JadeModel.class);
 
 	private Deque<Map<String, Object>> scopes = new LinkedList<Map<String, Object>>();
 	private Map<String, MixinNode> mixins = new HashMap<String, MixinNode>();


### PR DESCRIPTION
I have no clue why slf4j was added in the first place as it is unused, but it causes issues in applications that don't want to have it in their classpath. Everyone is happier this way.

Please pull, thanks!
