### PR TITLE
Added explicit self-closing tag support

### DIFF
--- a/src/main/java/de/neuland/jade4j/parser/node/TagNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/TagNode.java
@@ -58,12 +58,12 @@ public class TagNode extends AttributedNode {
             writer.append(">");
             return;
         }
-        if (isSelfClosing(template)) {
+        if (isSelfClosing(template) || isTrailingSlashSelfClosing() ) {
             writer.append("/>");
             return;
         }
         writer.append(">");
-        if (hasTextNode()) {
+        if (hasTextNode() && !textNode.getValue().equals("/")) {
             textNode.execute(writer, model, template);
         }
         if (hasBlock()) {
@@ -86,6 +86,10 @@ public class TagNode extends AttributedNode {
 
     public boolean isSelfClosing(JadeTemplate template) {
         return !template.isXml() && ArrayUtils.contains(selfClosing, name);
+    }
+
+    public boolean isTrailingSlashSelfClosing(){
+        return (hasTextNode() && textNode.getValue().equals("/"));
     }
 
     private String attributes(JadeModel model, JadeTemplate template) {

--- a/src/test/java/de/neuland/jade4j/parser/SelfClosingTagParserTest.java
+++ b/src/test/java/de/neuland/jade4j/parser/SelfClosingTagParserTest.java
@@ -1,0 +1,47 @@
+package de.neuland.jade4j.parser;
+
+
+import de.neuland.jade4j.parser.node.BlockNode;
+import de.neuland.jade4j.parser.node.Node;
+import de.neuland.jade4j.parser.node.TagNode;
+
+import org.junit.Test;
+
+import java.util.LinkedList;
+
+import static org.junit.Assert.*;
+
+public class SelfClosingTagParserTest extends ParserTest {
+
+	private BlockNode block;
+
+
+	@Test
+	public void shouldReturnTagsSelfClosed() {
+		loadInParser("selfClosingTag.jade");
+		block = (BlockNode) root;
+		LinkedList<Node> nodes = block.getNodes();
+		assertEquals(4, nodes.size());
+		
+		TagNode tag = (TagNode)block.getNodes().get(0);
+
+        assertTrue(tag.isTrailingSlashSelfClosing());
+        assertEquals(tag.getAttribute("bar"),"baz");
+
+        tag = (TagNode)block.getNodes().get(1);
+
+        assertTrue(tag.isTrailingSlashSelfClosing());
+        assertEquals(tag.getAttributes().size(),0);
+
+        tag = (TagNode)block.getNodes().get(2);
+
+        assertFalse(tag.isTrailingSlashSelfClosing());
+        assertEquals(tag.getAttribute("bar"),"baz");
+
+        tag = (TagNode)block.getNodes().get(3);
+
+        assertFalse(tag.isTrailingSlashSelfClosing());
+        assertEquals(tag.getAttributes().size(),0);
+
+	}
+}

--- a/src/test/resources/parser/selfClosingTag.jade
+++ b/src/test/resources/parser/selfClosingTag.jade
@@ -1,0 +1,4 @@
+foo(bar='baz')/
+foo/
+foo(bar='baz')
+foo


### PR DESCRIPTION
Added functionality for explicitly setting tags as self-closing tags by appending the '/' character.

For example: 

foo/
foo(bar='baz')/

Would yield:

<foo/>
<foo bar="baz"/>
