### PR TITLE
Fix double output of objects implementing Map and Iterable interfaces

### DIFF
--- a/src/main/java/de/neuland/jade4j/parser/node/EachNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/EachNode.java
@@ -39,12 +39,10 @@ public class EachNode extends Node {
 	private void run(IndentWriter writer, JadeModel model, Object result, JadeTemplate template) {
 		if (result instanceof Iterable<?>) {
 			runIterator(((Iterable<?>) result).iterator(), model, writer, template);
-		}
-		if (result.getClass().isArray()) {
+		} else if (result.getClass().isArray()) {
 			Iterator<?> iterator = IteratorUtils.arrayIterator(result);
 			runIterator(iterator, model, writer, template);
-		}
-		if (result instanceof Map) {
+		} else if (result instanceof Map) {
 			runMap((Map<String, Object>) result, model, writer, template);
 		}
 	}

--- a/src/test/java/de/neuland/jade4j/helper/beans/IterableMap.java
+++ b/src/test/java/de/neuland/jade4j/helper/beans/IterableMap.java
@@ -1,0 +1,13 @@
+package de.neuland.jade4j.helper.beans;
+
+import java.util.HashMap;
+import java.util.Iterator;
+
+public class IterableMap extends HashMap<String, String> implements Iterable<String> {
+
+    @Override
+    public Iterator<String> iterator() {
+        return this.values().iterator();
+    }
+
+}

--- a/src/test/java/de/neuland/jade4j/template/JadeRunFullTemplateTest.java
+++ b/src/test/java/de/neuland/jade4j/template/JadeRunFullTemplateTest.java
@@ -9,6 +9,7 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
+import de.neuland.jade4j.helper.beans.IterableMap;
 import org.junit.Test;
 
 import de.neuland.jade4j.JadeConfiguration;
@@ -17,37 +18,63 @@ import de.neuland.jade4j.exceptions.JadeCompilerException;
 import de.neuland.jade4j.model.JadeModel;
 
 public class JadeRunFullTemplateTest {
-	
-	@Test
-	public void testFullRun() throws IOException {
-		JadeConfiguration cfg = new JadeConfiguration();
-		//	cfg.setDirectoryForTemplateLoading(new File("/where/you/store/templates"));
-		Map<String, Object> root = new HashMap<String, Object>();
-		root.put("hello", "world");
-		root.put("hallo", null);
-		JadeModel model = new JadeModel(root);
 
-		JadeTemplate temp = cfg.getTemplate(getResourcePath("fullrun"));
+    private JadeConfiguration cfg = new JadeConfiguration();
 
-//		Writer out = new OutputStreamWriter(System.err);
-		StringWriter out = new StringWriter();
-		try {
+    @Test
+    public void testFullRun() throws IOException {
+
+        Map<String, Object> root = new HashMap<String, Object>();
+        root.put("hello", "world");
+        root.put("hallo", null);
+        JadeModel model = new JadeModel(root);
+
+        JadeTemplate temp = cfg.getTemplate(getResourcePath("fullrun"));
+
+        StringWriter out = new StringWriter();
+        try {
             temp.process(model, out);
         } catch (JadeCompilerException e) {
             e.printStackTrace();
             fail();
         }
-		out.flush();
-		assertEquals("<div><div>Hi everybody</div></div>", out.toString());
-	}
+        out.flush();
+        assertEquals("<div><div>Hi everybody</div></div>", out.toString());
+
+    }
+
+    @Test
+    public void testEachLoopWithIterableMap() throws Exception {
+
+        IterableMap users = new IterableMap();
+        users.put("bob", "Robert Smith");
+        users.put("alex", "Alex Supertramp");
+
+        Map<String, Object> root = new HashMap<String, Object>();
+        root.put("users", users);
+        JadeModel model = new JadeModel(root);
+
+        JadeTemplate temp = cfg.getTemplate(getResourcePath("each_loop"));
+
+        StringWriter out = new StringWriter();
+        try {
+            temp.process(model, out);
+        } catch (JadeCompilerException e) {
+            e.printStackTrace();
+            fail();
+        }
+        out.flush();
+        assertEquals("<ul><li>Robert Smith</li><li>Alex Supertramp</li></ul>", out.toString());
+
+    }
 
     public String getResourcePath(String fileName) {
-    	try {
-			return TestFileHelper.getRootResourcePath() + "/template/" + fileName;
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-		}
-    	return null;
+        try {
+            return TestFileHelper.getRootResourcePath() + "/template/" + fileName;
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 }
 

--- a/src/test/resources/template/each_loop.jade
+++ b/src/test/resources/template/each_loop.jade
@@ -1,0 +1,3 @@
+ul
+    each u in users
+        li= u


### PR DESCRIPTION
If the object used with "each" implements both Map and Iterable interfaces, it is included in the output twice.

Would be really great to have it fixed!

Thanks.
