### PR TITLE
Update ClasspathTemplateLoader.java

### DIFF
--- a/src/main/java/de/neuland/jade4j/template/ClasspathTemplateLoader.java
+++ b/src/main/java/de/neuland/jade4j/template/ClasspathTemplateLoader.java
@@ -22,7 +22,7 @@ public class ClasspathTemplateLoader implements TemplateLoader {
 
     @Override
     public Reader getReader(String name) throws IOException {
-        if(!name.endsWith(suffix))name = name + suffix;
+        if(!name.contains("."))name = name + suffix;
         return new InputStreamReader(Thread.currentThread().getContextClassLoader().getResourceAsStream(name), getEncoding());
     }
 


### PR DESCRIPTION
I'm using jade to create templates for html emails. For this we need to include the css directly into the html. So jade code such as
```
style
         include foundation.css
```
doesn't work. This works for me though. Assumption is that any dot will be part of extension and not part of the file path which I don't believe is allowed anyway. So it only tacks on .jade if no dot is in the path.