### PR TITLE
Changes to convert jade4j in a Bundle OSGI

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.2.4
+* Converted in bundle to install Jade4j into OSGI container like karaf
+
 ## 1.2.3 / 2016-06-17
 * Performance improvements
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,16 @@ You can read more about this in the [JEXL documentation](http://commons.apache.o
 
 If you want to use jade4j with Spring check out our [neuland/spring-jade4j](https://github.com/neuland/spring-jade4j) project.
 
+## OSGI Support
+
+If you want to use jade4j with OSGI, some changes was made to support OSGI installation in [karaf-4.1.0-SNAPSHOT](https://karaf.apache.org/download.html), this changes are available from jade4j-1.2.4-SNAPSHOT where it is a bundle, for test this feature you need to do this:
+
+- Download and Install [karaf-4.1.0-SNAPSHOT](https://karaf.apache.org/download.html)
+- Start karaf -> cd ${karaf_home}/bin/; ./karaf
+- Add the repo of this project with this karaf command: feature:repo-add mvn:de.neuland-bfi/jade4j-features/1.2.4-SNAPSHOT/xml/features
+- Install feature: feature:install jade4j-osgi
+
+
 <a name="breaking-changes"></a>
 ## Breaking Changes in 1.0.0
 In Version 1.0.0 we added a lot of features of JadeJs 1.11. There are also some Breaking Changes:

--- a/jade4j-features/pom.xml
+++ b/jade4j-features/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jade4j</artifactId>
+        <groupId>de.neuland-bfi</groupId>
+        <version>1.2.4-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jade4j-features</artifactId>
+    <name>${project.artifactId} :: Features OSGI for install Jade4j</name>
+    <description>Features OSGI for install Jade4j</description>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/classes/features.xml</file>
+                                    <type>xml</type>
+                                    <classifier>features</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <!--<pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.karaf.tooling</groupId>
+                    <artifactId>karaf-maven-plugin</artifactId>
+                    <version>${karaf.version}</version>
+                    <extensions>true</extensions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+
+                <configuration>
+                    <startLevel>50</startLevel>
+                    <aggregateFeatures>true</aggregateFeatures>
+                    <resolver>(obr)</resolver>
+                    <checkDependencyChange>true</checkDependencyChange>
+                    <failOnDependencyChange>false</failOnDependencyChange>
+                    <logDependencyChanges>true</logDependencyChanges>
+                    <overwriteChangedDependencies>true</overwriteChangedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>-->
+    </build>
+
+</project>

--- a/jade4j-features/src/main/resources/features.xml
+++ b/jade4j-features/src/main/resources/features.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ /*
+  ~  * Features OSGI for Jade4j
+  ~  */
+  -->
+<features name="jade4j-osgi" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+    <feature name="jade4j-osgi" version="${project.version}">
+        <details>${project.description}</details>
+        <bundle>mvn:org.apache.commons/commons-jexl/${commons-jexl.version}</bundle>
+        <bundle>mvn:com.googlecode.concurrentlinkedhashmap/concurrentlinkedhashmap-lru/${concurrentlinkedhashmap-lru.version}</bundle>
+        <bundle>mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
+        <bundle>mvn:commons-io/commons-io/${commons-io.version}</bundle>
+        <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
+        <bundle>wrap:mvn:org.pegdown/pegdown/${pegdown.version}</bundle>
+
+        <bundle>mvn:de.neuland-bfi/jade4j/${project.version}</bundle>
+    </feature>
+
+</features>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.neuland-bfi</groupId>
     <artifactId>jade4j</artifactId>
     <version>1.2.4-SNAPSHOT</version>
-    <packaging>bundle</packaging>
+    <packaging>pom</packaging>
     <name>jade4j</name>
     <description>Java implementation of the jade templating language</description>
     <parent>
@@ -17,7 +17,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-bundle-plugin.version>3.0.1</maven-bundle-plugin.version>
         <osgi.version>6.0.0</osgi.version>
+        <karaf.version>4.1.0-SNAPSHOT</karaf.version>
+        <commons-jexl.version>2.1.1</commons-jexl.version>
+        <concurrentlinkedhashmap-lru.version>1.4.2</concurrentlinkedhashmap-lru.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
+        <commons-io.version>2.5</commons-io.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
+        <pegdown.version>1.6.0</pegdown.version>
     </properties>
+
+    <modules>
+        <module>jade4j-features</module>
+    </modules>
 
     <issueManagement>
         <url>https://github.com/neuland/jade4j/issues</url>
@@ -122,7 +133,8 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>
-                            de.neuland.jade4j.*;version=${project.version}
+                            de.neuland.jade4j.*;version=${project.version},
+                            org.apache.commons.jexl2.jade
                         </Export-Package>
                         <Import-Package>
                             *
@@ -214,27 +226,27 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl</artifactId>
-            <version>2.1.1</version>
+            <version>${commons-jexl.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
+            <version>${commons-collections.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
             <artifactId>concurrentlinkedhashmap-lru</artifactId>
-            <version>1.4.2</version>
+            <version>${concurrentlinkedhashmap-lru.version}</version>
         </dependency>
 
         <!-- Testing -->
@@ -265,7 +277,7 @@
         <dependency>
             <groupId>org.pegdown</groupId>
             <artifactId>pegdown</artifactId>
-            <version>1.6.0</version>
+            <version>${pegdown.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.neuland-bfi</groupId>
     <artifactId>jade4j</artifactId>
     <version>1.2.4-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>jade4j</name>
     <description>Java implementation of the jade templating language</description>
     <parent>
@@ -13,6 +13,11 @@
         <version>7</version>
     </parent>
     <url>https://github.com/neuland/jade4j</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-bundle-plugin.version>3.0.1</maven-bundle-plugin.version>
+        <osgi.version>6.0.0</osgi.version>
+    </properties>
 
     <issueManagement>
         <url>https://github.com/neuland/jade4j/issues</url>
@@ -56,9 +61,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 
     <prerequisites>
         <maven>2.2.1</maven>
@@ -110,6 +112,24 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven-bundle-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Export-Package>
+                            de.neuland.jade4j.*;version=${project.version}
+                        </Export-Package>
+                        <Import-Package>
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
@@ -185,6 +205,12 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${osgi.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl</artifactId>

--- a/src/main/java/de/neuland/jade4j/expression/JexlExpressionHandler.java
+++ b/src/main/java/de/neuland/jade4j/expression/JexlExpressionHandler.java
@@ -1,7 +1,7 @@
 package de.neuland.jade4j.expression;
 
 import org.apache.commons.jexl2.Expression;
-import org.apache.commons.jexl2.JadeJexlEngine;
+import org.apache.commons.jexl2.jade.JadeJexlEngine;
 import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.MapContext;
 

--- a/src/main/java/org/apache/commons/jexl2/JadeIntrospect.java
+++ b/src/main/java/org/apache/commons/jexl2/JadeIntrospect.java
@@ -1,17 +1,11 @@
 package org.apache.commons.jexl2;
 
-import java.lang.reflect.Field;
-
-import org.apache.commons.jexl2.JexlInfo;
-import org.apache.commons.jexl2.internal.AbstractExecutor;
-import org.apache.commons.jexl2.internal.BooleanGetExecutor;
-import org.apache.commons.jexl2.internal.DuckGetExecutor;
-import org.apache.commons.jexl2.internal.ListGetExecutor;
-import org.apache.commons.jexl2.internal.MapGetExecutor;
-import org.apache.commons.jexl2.internal.PropertyGetExecutor;
+import org.apache.commons.jexl2.internal.*;
 import org.apache.commons.jexl2.introspection.JexlPropertyGet;
 import org.apache.commons.jexl2.introspection.UberspectImpl;
 import org.apache.commons.logging.Log;
+
+import java.lang.reflect.Field;
 
 public class JadeIntrospect extends UberspectImpl {
 

--- a/src/main/java/org/apache/commons/jexl2/jade/JadeIntrospect.java
+++ b/src/main/java/org/apache/commons/jexl2/jade/JadeIntrospect.java
@@ -1,5 +1,6 @@
-package org.apache.commons.jexl2;
+package org.apache.commons.jexl2.jade;
 
+import org.apache.commons.jexl2.JexlInfo;
 import org.apache.commons.jexl2.internal.*;
 import org.apache.commons.jexl2.introspection.JexlPropertyGet;
 import org.apache.commons.jexl2.introspection.UberspectImpl;

--- a/src/main/java/org/apache/commons/jexl2/jade/JadeJexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl2/jade/JadeJexlArithmetic.java
@@ -1,6 +1,7 @@
-package org.apache.commons.jexl2;
+package org.apache.commons.jexl2.jade;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.jexl2.JexlArithmetic;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/src/main/java/org/apache/commons/jexl2/jade/JadeJexlEngine.java
+++ b/src/main/java/org/apache/commons/jexl2/jade/JadeJexlEngine.java
@@ -1,5 +1,9 @@
-package org.apache.commons.jexl2;
+package org.apache.commons.jexl2.jade;
 
+
+import org.apache.commons.jexl2.Interpreter;
+import org.apache.commons.jexl2.JexlContext;
+import org.apache.commons.jexl2.JexlEngine;
 
 public class JadeJexlEngine extends JexlEngine {
 

--- a/src/main/java/org/apache/commons/jexl2/jade/JadeJexlInterpreter.java
+++ b/src/main/java/org/apache/commons/jexl2/jade/JadeJexlInterpreter.java
@@ -1,8 +1,9 @@
-package org.apache.commons.jexl2;
+package org.apache.commons.jexl2.jade;
 
 import org.apache.commons.jexl2.Interpreter;
 import org.apache.commons.jexl2.JexlContext;
 import org.apache.commons.jexl2.JexlEngine;
+import org.apache.commons.jexl2.JexlException;
 
 public class JadeJexlInterpreter extends Interpreter {
 


### PR DESCRIPTION
## OSGI Support

If you want to use jade4j with OSGI, some changes was made to support OSGI installation in [karaf-4.1.0-SNAPSHOT](https://karaf.apache.org/download.html), this changes are available from jade4j-1.2.4-SNAPSHOT where it is a bundle, for test this feature you need to do this:

- Download and Install [karaf-4.1.0-SNAPSHOT](https://karaf.apache.org/download.html)
- Start karaf -> cd ${karaf_home}/bin/; ./karaf
- Add the repo of this project with this karaf command: feature:repo-add mvn:de.neuland-bfi/jade4j-features/1.2.4-SNAPSHOT/xml/features
- Install feature: feature:install jade4j-osgi