### PR TITLE
Read files using utf8 in the tests

### DIFF
--- a/src/test/java/de/neuland/jade4j/compiler/CompilerTest.java
+++ b/src/test/java/de/neuland/jade4j/compiler/CompilerTest.java
@@ -493,7 +493,7 @@ public class CompilerTest {
     private String readFile(String fileName) {
         try {
             return FileUtils.readFileToString(new File(TestFileHelper
-                    .getCompilerResourcePath(fileName)));
+                    .getCompilerResourcePath(fileName)),"UTF-8");
         } catch (Exception e) {
             // e.printStackTrace();
         }

--- a/src/test/java/de/neuland/jade4j/compiler/IssuesTest.java
+++ b/src/test/java/de/neuland/jade4j/compiler/IssuesTest.java
@@ -80,7 +80,7 @@ public class IssuesTest {
     }
 
     private String readFile(String fileName) throws IOException {
-        return FileUtils.readFileToString(new File(TestFileHelper.getIssuesResourcePath(fileName)));
+        return FileUtils.readFileToString(new File(TestFileHelper.getIssuesResourcePath(fileName)),"UTF-8");
     }
 
     @Parameterized.Parameters(name="{0}")


### PR DESCRIPTION
In windows(or my machine) the test resource files are not loaded using UTF8 so when I do an `mvn clean install`, some tests like `CompilerTest.mixinWithComplexParameter` and   `IssuesTest.shouldCompileJadeToHtml 65.jade` kept failing.

Regards,
Ronald