### PR TITLE
Add simple server for prototyping inspired by handlebars-proto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.neuland-bfi</groupId>
     <artifactId>jade4j</artifactId>
@@ -30,8 +31,8 @@
         <url>https://github.com/neuland/jade4j</url>
         <connection>scm:git:git://github.com/neuland/jade4j.git</connection>
         <developerConnection>scm:git:git@github.com:neuland/jade4j.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <developers>
         <developer>
@@ -54,10 +55,18 @@
             <url>https://github.com/chbloemer</url>
             <id>chbloemer</id>
         </developer>
+        <developer>
+            <name>Guilherme I F L Weizenmann</name>
+            <url>https://github.com/giflw</url>
+            <id>giflw</id>
+        </developer>
     </developers>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.7</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
 
     <prerequisites>
@@ -92,8 +101,36 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jade4j-proto</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>appassembler-maven-plugin</artifactId>
+                        <version>1.10</version>
+                        <configuration>
+                            <programs>
+                                <program>
+                                    <mainClass>de.neuland.jade4j.proto.Jade4JProto</mainClass>
+                                    <id>jade4j-proto</id>
+                                </program>
+                            </programs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>assemble</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
-    
+
     <build>
         <pluginManagement>
             <plugins>
@@ -164,7 +201,9 @@
                     <execution>
                         <id>deploy</id>
                         <phase>deploy</phase>
-                        <goals><goal>deploy</goal></goals>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -218,11 +257,23 @@
             <version>1.4.2</version>
         </dependency>
         <dependency>
-          <groupId>com.vladsch.flexmark</groupId>
-          <artifactId>flexmark-all</artifactId>
-          <version>0.28.2</version>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-all</artifactId>
+            <version>0.28.2</version>
         </dependency>
-
+        <!-- Optionals for Proto -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.22</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>1.1.1</version>
+            <optional>true</optional>
+        </dependency>
         <!-- Testing -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/de/neuland/jade4j/proto/Jade4JProto.java
+++ b/src/main/java/de/neuland/jade4j/proto/Jade4JProto.java
@@ -1,0 +1,101 @@
+package de.neuland.jade4j.proto;
+
+import de.neuland.jade4j.Jade4J;
+import org.yaml.snakeyaml.Yaml;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+
+import static spark.Spark.*;
+
+public class Jade4JProto {
+
+    private static final String[] MODEL_EXTS = {"yml", "json"};
+
+
+    public static void main(String[] args) {
+
+        if (args.length == 1 && (args[0].equals("-h") || args[0].equals("--help"))) {
+            help();
+            System.exit(0);
+        }
+
+        int port = 4567;
+        String baseDirAux = System.getProperty("user.dir");
+
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if ("--port".equals(arg)) {
+                i++;
+                port = Integer.parseInt(args[i]);
+            } else {
+                baseDirAux = arg;
+            }
+        }
+
+        final String baseDir = Paths.get(baseDirAux).normalize().toAbsolutePath().toString();
+
+        System.out.println("=========== Jade4J :: PROTO ===========");
+        System.out.println("PORT:     " + port);
+        System.out.println("BASE DIR: " + baseDir);
+        System.out.println("=======================================");
+
+        setIpAddress("0.0.0.0");
+        setPort(port);
+
+        get(new Route("/*") {
+            @Override
+            public Object handle(Request request, Response response) {
+                String relativePath = request.pathInfo();
+                relativePath = relativePath.equals("/") ? "/index" : relativePath;
+                System.out.println("RENDERING: " + relativePath);
+                String absolutePath = baseDir + relativePath;
+                String jadeFile = absolutePath + ".jade";
+                System.out.println("\t\tJADE:  " + jadeFile);
+                try {
+                    response.type("text/html");
+                    return Jade4J.render(jadeFile, load(absolutePath), true);
+                } catch (IOException e) {
+                    response.type("text/plain");
+                    return "Error: " + e.getMessage();
+                }
+            }
+        });
+    }
+
+    private static void help() {
+        System.out.println("jade4j-proto [directory] [--port <port>]");
+    }
+
+    private static Map load(String name) {
+        Map model = Collections.emptyMap();
+        for (String ext : MODEL_EXTS) {
+            File file = new File(name + "." + ext);
+            if (file.exists()) {
+                System.out.println("\t\tMODEL: " + file);
+                model = load(file);
+            }
+        }
+        if (model.isEmpty()) {
+            System.out.println("\t\tModel is empty!");
+        }
+        return model;
+    }
+
+    private static Map load(File file) {
+        try {
+            Yaml yaml = new Yaml();
+            return yaml.load(new FileReader(file));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return Collections.emptyMap();
+    }
+}

--- a/src/test/resources/proto/index.jade
+++ b/src/test/resources/proto/index.jade
@@ -1,0 +1,12 @@
+doctype html
+html
+  head
+    title= pageName
+    link(rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css")
+  body
+    ol#books
+      each book in books
+        li
+          strong #{book.author}
+          | 
+          | #{book.title}

--- a/src/test/resources/proto/index.yml
+++ b/src/test/resources/proto/index.yml
@@ -1,0 +1,7 @@
+pageName: Jade4J
+books:
+- author: Foo
+  title: T
+- author: Bar
+  title: TT
+


### PR DESCRIPTION
Add a simple server for prototyping.

- -h or --help show simple help message
- --port set port to run, or run on 4567 if not given
- use current directory or given one to serve files
- file to serve is given in url
- if a yml or json file with same name as template exists, it is used as model in rendering
- to access a file called "foo.jade" use http://localhost:4567/foo
- to access a file called "bar.jade" in a directory called "foo" use http://localhost:4567/foo/bar

I've added a profile called jade4j-proto to execute appassembler plugin to create a distributable folder