### PR TITLE
Copy non local vars in first matching scope when popScope

### DIFF
--- a/src/test/java/de/neuland/jade4j/compiler/IssuesTest.java
+++ b/src/test/java/de/neuland/jade4j/compiler/IssuesTest.java
@@ -3,30 +3,33 @@ package de.neuland.jade4j.compiler;
 import de.neuland.jade4j.Jade4J;
 import de.neuland.jade4j.JadeConfiguration;
 import de.neuland.jade4j.TestFileHelper;
-import de.neuland.jade4j.expression.JsExpressionHandler;
-import de.neuland.jade4j.filter.*;
+import de.neuland.jade4j.filter.CDATAFilter;
+import de.neuland.jade4j.filter.CssFilter;
+import de.neuland.jade4j.filter.CustomTestFilter;
+import de.neuland.jade4j.filter.JsFilter;
+import de.neuland.jade4j.filter.MarkdownFilter;
+import de.neuland.jade4j.filter.PlainFilter;
+import de.neuland.jade4j.filter.VerbatimFilter;
 import de.neuland.jade4j.template.ClasspathTemplateLoader;
 import de.neuland.jade4j.template.FileTemplateLoader;
 import de.neuland.jade4j.template.JadeTemplate;
 import de.neuland.jade4j.template.TemplateLoader;
-import org.apache.commons.io.Charsets;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.*;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class IssuesTest {
-    private static String[] ignoredCases = new String[]{"100","131","153"};
+    private static String[] ignoredCases = new String[]{"100","131"};
 
     private String file;
 

--- a/src/test/resources/compiler/exceptions/error.html
+++ b/src/test/resources/compiler/exceptions/error.html
@@ -125,7 +125,7 @@
   </head>
   <body>
     <h1>Jade Compiler Exception</h1>
-    <p id="detail">unable to evaluate [non.existing.query()] - JexlException de.neuland.jade4j.expression.JexlExpressionHandler.evaluateExpression@40![13,20]: 'non.existing.query();' attempting to call method on null in ../compiler/exceptions/error.jade:9</p>
+    <p id="detail">unable to evaluate [non.existing.query()] - JexlException de.neuland.jade4j.expression.JexlExpressionHandler.evaluateExpression@46![13,20]: 'non.existing.query();' attempting to call method on null in ../compiler/exceptions/error.jade:9</p>
     <h2>In ../compiler/exceptions/error.jade at line 9.</h2>
     <div>
       <pre><span class="line">5</span><span class="code">    body {</span></pre>


### PR DESCRIPTION
Resolves issue #153 
Introduced non-local variables to the model.
What I don´t like at this solution: I introduced some logic in JadeModel.popScope(). But did not find a better place to contain this logic.

Update: Benchmark Tool shows no impact on performance.

PR #158 can be closed after merging this PR.