### PR TITLE
maven pom flexmark-all is too much

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,9 +218,9 @@
             <version>1.4.2</version>
         </dependency>
         <dependency>
-          <groupId>com.vladsch.flexmark</groupId>
-          <artifactId>flexmark-all</artifactId>
-          <version>0.28.2</version>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark</artifactId>
+            <version>0.60.2</version>
         </dependency>
 
         <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark</artifactId>
-            <version>0.60.2</version>
+            <version>0.42.14</version>
         </dependency>
 
         <!-- Testing -->


### PR DESCRIPTION
When it comes to flexmark it is enough to depend on core library.

See also issue https://github.com/neuland/jade4j/issues/187

This pull request changes the dependency and also upgrades the flexmark version used.