### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 
 dist: trusty
 sudo: required
+cache:
+  directories:
+  - $HOME/.m2
 jdk:
   - oraclejdk9
   - oraclejdk8


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.